### PR TITLE
Development

### DIFF
--- a/TheRealDealGym.Core/Contracts/IClassService.cs
+++ b/TheRealDealGym.Core/Contracts/IClassService.cs
@@ -25,7 +25,7 @@ namespace TheRealDealGym.Core.Contracts
 
         Task<ClassDetailsModel> ClassDetailsByIdAsync(Guid classId);
 
-        Task EditAsync(Guid classId, ClassFormModel model);
+        Task EditAsync(Guid classId, ClassFormModel model, Guid trainerId);
 
         Task<ClassFormModel> GetClassFormModelByIdAsync(Guid classId);
 

--- a/TheRealDealGym.Core/Services/RoomService.cs
+++ b/TheRealDealGym.Core/Services/RoomService.cs
@@ -88,7 +88,7 @@ namespace TheRealDealGym.Core.Services
 
             if (classesInThisRoom.Any())
             {
-                throw new Exception("You cannot delete this room because there's currently classes, schduled for it!");
+                throw new Exception("You cannot delete this room because there's currently classes, scheduled for it!");
             }
 
             await repository.DeleteAsync<Room>(roomId);
@@ -104,6 +104,15 @@ namespace TheRealDealGym.Core.Services
 
             if (room != null)
             {
+                var classesInThisRoom = await repository.AllReadOnly<Class>()
+                .Where(c => c.RoomId == roomId)
+                .ToListAsync();
+
+                if (classesInThisRoom.Any())
+                {
+                    throw new Exception("You cannot edit this room because there's currently classes, scheduled for it!");
+                }
+
                 room.Type = model.Type;
                 room.Capacity = model.Capacity;
                 await repository.SaveChangesAsync();

--- a/TheRealDealGym.Core/Services/RoomService.cs
+++ b/TheRealDealGym.Core/Services/RoomService.cs
@@ -82,6 +82,15 @@ namespace TheRealDealGym.Core.Services
         /// </summary>
         public async Task DeleteAsync(Guid roomId)
         {
+            var classesInThisRoom = await repository.AllReadOnly<Class>()
+                .Where(c => c.RoomId == roomId)
+                .ToListAsync();
+
+            if (classesInThisRoom.Any())
+            {
+                throw new Exception("You cannot delete this room because there's currently classes, schduled for it!");
+            }
+
             await repository.DeleteAsync<Room>(roomId);
             await repository.SaveChangesAsync();
         }

--- a/TheRealDealGym.Core/Services/SportService.cs
+++ b/TheRealDealGym.Core/Services/SportService.cs
@@ -78,6 +78,14 @@ namespace TheRealDealGym.Core.Services
         /// </summary>
         public async Task DeleteAsync(Guid sportId)
         {
+            var classesInForThisSport = await repository.AllReadOnly<Class>()
+                .Where(c => c.SportId == sportId)
+                .ToListAsync();
+
+            if (classesInForThisSport.Any())
+            {
+                throw new Exception("You cannot delete this sport because there's currently classes, scheduled for it!");
+            }
             await repository.DeleteAsync<Sport>(sportId);
             await repository.SaveChangesAsync();
         }
@@ -91,6 +99,15 @@ namespace TheRealDealGym.Core.Services
 
             if (sport != null)
             {
+                var classesInForThisSport = await repository.AllReadOnly<Class>()
+                .Where(c => c.SportId == sportId)
+                .ToListAsync();
+
+                if (classesInForThisSport.Any())
+                {
+                    throw new Exception("You cannot edit this sport because there's currently classes, scheduled for it!");
+                }
+
                 sport.Title = model.Title;
                 await repository.SaveChangesAsync();
             }

--- a/TheRealDealGym.Infrastructure/Data/ApplicationDbContext.cs
+++ b/TheRealDealGym.Infrastructure/Data/ApplicationDbContext.cs
@@ -16,15 +16,15 @@ namespace TheRealDealGym.Infrastructure.Data
         protected override void OnModelCreating(ModelBuilder builder)
         {
             // COMMENT THE BELOW CONFIGURATIONS BEFORE RUNNING THE UNIT TESTS, UNCOMMENT BEFORE RUNNING THE APP:
-            //builder.ApplyConfiguration(new UserConfiguration());
-            //builder.ApplyConfiguration(new TrainerConfiguration());
-            //builder.ApplyConfiguration(new SportConfiguration());
-            //builder.ApplyConfiguration(new RoomConfiguration());
-            //builder.ApplyConfiguration(new ClassConfiguration());
-            //builder.ApplyConfiguration(new BookingConfiguration());
-            //builder.ApplyConfiguration(new JobAdvertConfiguration());
-            //builder.ApplyConfiguration(new JobApplicationConfiguration());
-            //builder.ApplyConfiguration(new UserClaimsConfiguration());
+            builder.ApplyConfiguration(new UserConfiguration());
+            builder.ApplyConfiguration(new TrainerConfiguration());
+            builder.ApplyConfiguration(new SportConfiguration());
+            builder.ApplyConfiguration(new RoomConfiguration());
+            builder.ApplyConfiguration(new ClassConfiguration());
+            builder.ApplyConfiguration(new BookingConfiguration());
+            builder.ApplyConfiguration(new JobAdvertConfiguration());
+            builder.ApplyConfiguration(new JobApplicationConfiguration());
+            builder.ApplyConfiguration(new UserClaimsConfiguration());
 
             base.OnModelCreating(builder);
         }

--- a/TheRealDealGym.Infrastructure/Data/ApplicationDbContext.cs
+++ b/TheRealDealGym.Infrastructure/Data/ApplicationDbContext.cs
@@ -16,15 +16,15 @@ namespace TheRealDealGym.Infrastructure.Data
         protected override void OnModelCreating(ModelBuilder builder)
         {
             // COMMENT THE BELOW CONFIGURATIONS BEFORE RUNNING THE UNIT TESTS, UNCOMMENT BEFORE RUNNING THE APP:
-            builder.ApplyConfiguration(new UserConfiguration());
-            builder.ApplyConfiguration(new TrainerConfiguration());
-            builder.ApplyConfiguration(new SportConfiguration());
-            builder.ApplyConfiguration(new RoomConfiguration());
-            builder.ApplyConfiguration(new ClassConfiguration());
-            builder.ApplyConfiguration(new BookingConfiguration());
-            builder.ApplyConfiguration(new JobAdvertConfiguration());
-            builder.ApplyConfiguration(new JobApplicationConfiguration());
-            builder.ApplyConfiguration(new UserClaimsConfiguration());
+            //builder.ApplyConfiguration(new UserConfiguration());
+            //builder.ApplyConfiguration(new TrainerConfiguration());
+            //builder.ApplyConfiguration(new SportConfiguration());
+            //builder.ApplyConfiguration(new RoomConfiguration());
+            //builder.ApplyConfiguration(new ClassConfiguration());
+            //builder.ApplyConfiguration(new BookingConfiguration());
+            //builder.ApplyConfiguration(new JobAdvertConfiguration());
+            //builder.ApplyConfiguration(new JobApplicationConfiguration());
+            //builder.ApplyConfiguration(new UserClaimsConfiguration());
 
             base.OnModelCreating(builder);
         }

--- a/TheRealDealGym.UnitTests/ClassServiceTests.cs
+++ b/TheRealDealGym.UnitTests/ClassServiceTests.cs
@@ -289,6 +289,30 @@ namespace TheRealDealGym.UnitTests
         }
 
         [Test]
+        public async Task CreateAsync_ShouldReturnTrainerNotAvailable()
+        {
+            var classFormModel = new ClassFormModel()
+            {
+                Title = "New Class - swimming",
+                Description = "This is a brand new swimming class",
+                Date = DateTime.Now.ToString("yyyy-MM-dd"),
+                Time = DateTime.Now.AddMinutes(17).ToString("HH:mm:ss"),
+                Price = 14.50m,
+                SportId = Guid.Parse("4af95cd3-3829-4553-b6df-5d6b130a4ba8"),
+                RoomId = Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d301")
+            };
+
+            try
+            {
+                var newClass = await classService.CreateAsync(classFormModel, Guid.Parse("04feea53-473b-44b0-8987-685eedfd862c"));
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex.Message, Is.EqualTo("For this date you already have another class around this time, please select different time."));
+            }
+        }
+
+        [Test]
         public async Task CreateAsync_ShouldReturnSelectValidDateAndTime()
         {
             var classFormModel = new ClassFormModel()
@@ -335,7 +359,7 @@ namespace TheRealDealGym.UnitTests
                 RoomId = Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"),
                 SportId = Guid.Parse("91458b63-8fc3-479b-b3b8-a7a920ec984e")
             };
-            await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit);
+            await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit, Guid.Parse("10c4a0b0-16ca-464a-bdc4-6f8fe432de42"));
 
             var editedClass = await classService.GetClassFormModelByIdAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"));
             var editedTitle = editedClass.Title;
@@ -368,7 +392,7 @@ namespace TheRealDealGym.UnitTests
 
             try
             {
-                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit);
+                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit, Guid.Parse("10c4a0b0-16ca-464a-bdc4-6f8fe432de42"));
             }
             catch (Exception ex)
             {
@@ -392,11 +416,35 @@ namespace TheRealDealGym.UnitTests
 
             try
             {
-                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit);
+                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit, Guid.Parse("10c4a0b0-16ca-464a-bdc4-6f8fe432de42"));
             }
             catch (Exception ex)
             {
                 Assert.That(ex.Message, Is.EqualTo("Selected room is not available for the chosen time slot."));
+            }
+        }
+
+        [Test]
+        public async Task EditAsync_ShouldNotBeEdited_TrainerNotAvailable()
+        {
+            var classToEdit = new ClassFormModel()
+            {
+                Title = "Edited Advanced Muay Thai Class",
+                Description = "This class is dited",
+                Date = DateTime.Now.ToString("yyyy-MM-dd"),
+                Time = DateTime.Now.AddMinutes(15).ToString("HH:mm:ss"),
+                Price = 12m,
+                RoomId = Guid.Parse("07c92ab2-93a1-43dd-8fc8-3e16541a9570"),
+                SportId = Guid.Parse("91458b63-8fc3-479b-b3b8-a7a920ec984e")
+            };
+
+            try
+            {
+                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit, Guid.Parse("10c4a0b0-16ca-464a-bdc4-6f8fe432de42"));
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex.Message, Is.EqualTo("For this date you already have another class around this time, please select different time."));
             }
         }
 
@@ -416,7 +464,7 @@ namespace TheRealDealGym.UnitTests
 
             try
             {
-                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit);
+                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit, Guid.Parse("10c4a0b0-16ca-464a-bdc4-6f8fe432de42"));
             }
             catch (Exception ex)
             {
@@ -440,7 +488,7 @@ namespace TheRealDealGym.UnitTests
 
             try
             {
-                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit);
+                await classService.EditAsync(Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"), classToEdit, Guid.Parse("10c4a0b0-16ca-464a-bdc4-6f8fe432de42"));
             }
             catch (Exception ex)
             {

--- a/TheRealDealGym.UnitTests/RoomServiceTests.cs
+++ b/TheRealDealGym.UnitTests/RoomServiceTests.cs
@@ -163,6 +163,27 @@ namespace TheRealDealGym.UnitTests
         }
 
         [Test]
+        public async Task EditRoomAsync_ShouldNotEditRoomDetails()
+        {
+            var roomModel = new RoomServiceModel()
+            {
+                Id = Guid.Parse("07c92ab2-93a1-43dd-8fc8-3e16541a9573"),
+                Capacity = 17,
+                Type = "Edited Fighting room"
+            };
+
+            try
+            {
+                await roomService.EditAsync(Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"), roomModel);
+            }
+            catch (Exception ex)
+            {
+
+                Assert.That(ex.Message, Is.EqualTo("You cannot edit this room because there's currently classes, scheduled for it!"));
+            }
+        }
+
+        [Test]
         public async Task ExistsByIdAsync_ShouldReturnTrue()
         {
             var roomExistsById = await roomService.ExistsByIdAsync(Guid.Parse("07c92ab2-93a1-43dd-8fc8-3e16541a9573"));

--- a/TheRealDealGym.UnitTests/RoomServiceTests.cs
+++ b/TheRealDealGym.UnitTests/RoomServiceTests.cs
@@ -46,8 +46,22 @@ namespace TheRealDealGym.UnitTests
                 Capacity = 16,
 
             };
+
+            var muayThaiClass = new Class()
+            {
+                Id = Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"),
+                Title = "Advanced MuayThai",
+                Description = "this is advanced class for fighters",
+                Price = 20,
+                DateAndTime = DateTime.Now,
+                TrainerId = Guid.Parse("10c4a0b0-16ca-464a-bdc4-6f8fe432de42"),
+                RoomId = Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"),
+                SportId = Guid.Parse("91458b63-8fc3-479b-b3b8-a7a920ec984e")
+            };
+
             await repository.AddAsync(fightingRoom);
             await repository.AddAsync(swimmingPool);
+            await repository.AddAsync(muayThaiClass);
 
             await repository.SaveChangesAsync();
         }
@@ -109,7 +123,7 @@ namespace TheRealDealGym.UnitTests
         [Test]
         public async Task DeleteAsync_ShouldDeleteARoom()
         {
-            await roomService.DeleteAsync(Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"));
+            await roomService.DeleteAsync(Guid.Parse("07c92ab2-93a1-43dd-8fc8-3e16541a9573"));
             var roomsLeft = await roomService.AllRoomsAsync();
             int roomsCount = roomsLeft.Rooms.Count();
 
@@ -117,18 +131,32 @@ namespace TheRealDealGym.UnitTests
         }
 
         [Test]
+        public async Task DeleteAsync_ShouldNotDeleteARoom()
+        {
+            try
+            {
+                await roomService.DeleteAsync(Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"));
+            }
+            catch (Exception ex)
+            {
+
+                Assert.That(ex.Message, Is.EqualTo("You cannot delete this room because there's currently classes, scheduled for it!"));
+            }
+        }
+
+        [Test]
         public async Task EditRoomAsync_ShouldEditRoomDetails()
         {
             var roomModel = new RoomServiceModel()
             {
-                Id = Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"),
+                Id = Guid.Parse("07c92ab2-93a1-43dd-8fc8-3e16541a9573"),
                 Capacity = 17,
                 Type = "Edited Fighting room"
             };
 
-            await roomService.EditAsync(Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"), roomModel);
+            await roomService.EditAsync(Guid.Parse("07c92ab2-93a1-43dd-8fc8-3e16541a9573"), roomModel);
 
-            var editedRoom = await roomService.GetByIdAsync(Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"));
+            var editedRoom = await roomService.GetByIdAsync(Guid.Parse("07c92ab2-93a1-43dd-8fc8-3e16541a9573"));
 
             Assert.That(editedRoom.Capacity, Is.EqualTo(17));
             Assert.That(editedRoom.Type, Is.EqualTo("Edited Fighting room"));

--- a/TheRealDealGym.UnitTests/RoomServiceTests.cs
+++ b/TheRealDealGym.UnitTests/RoomServiceTests.cs
@@ -1,13 +1,11 @@
-﻿using TheRealDealGym.Core.Contracts;
-using TheRealDealGym.Infrastructure.Data.Common;
-using TheRealDealGym.Infrastructure.Data;
-using Microsoft.EntityFrameworkCore;
-using TheRealDealGym.Core.Services;
-using TheRealDealGym.Infrastructure.Data.Models;
+﻿using Microsoft.EntityFrameworkCore;
+using TheRealDealGym.Core.Contracts;
 using TheRealDealGym.Core.Enums;
-using TheRealDealGym.Core.Models.Class;
 using TheRealDealGym.Core.Models.Room;
-using TheRealDealGym.Core.Models.Trainer;
+using TheRealDealGym.Core.Services;
+using TheRealDealGym.Infrastructure.Data;
+using TheRealDealGym.Infrastructure.Data.Common;
+using TheRealDealGym.Infrastructure.Data.Models;
 
 namespace TheRealDealGym.UnitTests
 {

--- a/TheRealDealGym.UnitTests/RoomServiceTests.cs
+++ b/TheRealDealGym.UnitTests/RoomServiceTests.cs
@@ -176,7 +176,6 @@ namespace TheRealDealGym.UnitTests
             }
             catch (Exception ex)
             {
-
                 Assert.That(ex.Message, Is.EqualTo("You cannot edit this room because there's currently classes, scheduled for it!"));
             }
         }

--- a/TheRealDealGym.UnitTests/SportServiceTests.cs
+++ b/TheRealDealGym.UnitTests/SportServiceTests.cs
@@ -137,6 +137,25 @@ namespace TheRealDealGym.UnitTests
             Assert.That(editedSport.Title, Is.EqualTo("Swimming edited"));
         }
 
+        [Test]
+        public async Task EditSportAsync_ShouldNotEditSportDetails()
+        {
+            var sportInfoModel = new SportInfoModel()
+            {
+                Id = Guid.Parse("91458b63-8fc3-479b-b3b8-a7a920ec984e"),
+                Title = "MuayThai edited"
+            };
+
+            try
+            {
+                await sportService.EditAsync(Guid.Parse("91458b63-8fc3-479b-b3b8-a7a920ec984e"), sportInfoModel);
+            }
+            catch (Exception ex)
+            {
+                Assert.That(ex.Message, Is.EqualTo("You cannot edit this sport because there's currently classes, scheduled for it!"));
+            }
+
+        }
 
         [Test]
         public async Task ExistsByIdAsync_ShouldReturnTrue()

--- a/TheRealDealGym.UnitTests/SportServiceTests.cs
+++ b/TheRealDealGym.UnitTests/SportServiceTests.cs
@@ -42,8 +42,22 @@ namespace TheRealDealGym.UnitTests
                 Id = Guid.Parse("4af95cd3-3829-4553-b6df-5d6b130a4ba8"),
                 Title = "Swimming"
             };
+
+            var muayThaiClass = new Class()
+            {
+                Id = Guid.Parse("ad61a644-76c7-4366-9686-82b65a42fd14"),
+                Title = "Advanced MuayThai",
+                Description = "this is advanced class for fighters",
+                Price = 20,
+                DateAndTime = DateTime.Now,
+                TrainerId = Guid.Parse("10c4a0b0-16ca-464a-bdc4-6f8fe432de42"),
+                RoomId = Guid.Parse("b62f8c2e-f842-4812-ae27-70be5e24d309"),
+                SportId = Guid.Parse("91458b63-8fc3-479b-b3b8-a7a920ec984e")
+            };
+
             await repository.AddAsync(muayThaiSport);
             await repository.AddAsync(swimmingSport);
+            await repository.AddAsync(muayThaiClass);
 
             await repository.SaveChangesAsync();
         }
@@ -94,6 +108,20 @@ namespace TheRealDealGym.UnitTests
         }
 
         [Test]
+        public async Task DeleteAsync_ShouldNotDeleteASport()
+        {
+            try
+            {
+                await sportService.DeleteAsync(Guid.Parse("91458b63-8fc3-479b-b3b8-a7a920ec984e"));
+            }
+            catch (Exception ex)
+            {
+
+                Assert.That(ex.Message, Is.EqualTo("You cannot delete this sport because there's currently classes, scheduled for it!"));
+            }
+        }
+
+        [Test]
         public async Task EditSportAsync_ShouldEditSportDetails()
         {
             var sportInfoModel = new SportInfoModel()
@@ -108,6 +136,7 @@ namespace TheRealDealGym.UnitTests
 
             Assert.That(editedSport.Title, Is.EqualTo("Swimming edited"));
         }
+
 
         [Test]
         public async Task ExistsByIdAsync_ShouldReturnTrue()

--- a/TheRealDealGym/Areas/Admin/Controllers/RoomController.cs
+++ b/TheRealDealGym/Areas/Admin/Controllers/RoomController.cs
@@ -97,10 +97,19 @@ namespace TheRealDealGym.Areas.Admin.Controllers
                 return View(model);
             }
 
-            await roomService.EditAsync(roomId, model);
+            try
+            {
+                await roomService.EditAsync(roomId, model);
 
-            TempData[MessageWarning] = "You have successfully edited this room!";
-            return RedirectToAction(nameof(Index), "Room");
+                TempData[MessageWarning] = "You have successfully edited this room!";
+                return RedirectToAction(nameof(Index), "Room");
+            }
+            catch (Exception ex)
+            {
+                TempData[MessageError] = ex.Message;
+                return RedirectToAction(nameof(Index), "Room");
+            }
+            
         }
 
         /// <summary>

--- a/TheRealDealGym/Areas/Admin/Controllers/RoomController.cs
+++ b/TheRealDealGym/Areas/Admin/Controllers/RoomController.cs
@@ -3,6 +3,7 @@ using TheRealDealGym.Core.Contracts;
 using TheRealDealGym.Core.Models.Job;
 using TheRealDealGym.Core.Models.Room;
 using TheRealDealGym.Core.Services;
+using TheRealDealGym.Infrastructure.Data.Models;
 using static TheRealDealGym.Core.Constants.MessageConstants;
 
 namespace TheRealDealGym.Areas.Admin.Controllers
@@ -113,10 +114,18 @@ namespace TheRealDealGym.Areas.Admin.Controllers
                 return BadRequest();
             }
 
-            await roomService.DeleteAsync(roomId);
+            try
+            {
+                await roomService.DeleteAsync(roomId);
 
-            TempData[MessageError] = "You have successfully deleted this room!";
-            return RedirectToAction(nameof(Index), "Room");
+                TempData[MessageError] = "You have successfully deleted this room!";
+                return RedirectToAction(nameof(Index), "Room");
+            }
+            catch (Exception ex)
+            {
+                TempData[MessageError] = ex.Message;
+                return RedirectToAction(nameof(Index), "Room");
+            }
         }
     }
 }

--- a/TheRealDealGym/Areas/Admin/Controllers/SportController.cs
+++ b/TheRealDealGym/Areas/Admin/Controllers/SportController.cs
@@ -95,10 +95,19 @@ namespace TheRealDealGym.Areas.Admin.Controllers
                 return View(model);
             }
 
-            await sportService.EditAsync(sportId, model);
+            try
+            {
+                await sportService.EditAsync(sportId, model);
 
-            TempData[MessageWarning] = "You have successfully edited this sport!";
-            return RedirectToAction(nameof(Index), "Sport");
+                TempData[MessageWarning] = "You have successfully edited this sport!";
+                return RedirectToAction(nameof(Index), "Sport");
+            }
+            catch (Exception ex)
+            {
+                TempData[MessageError] = ex.Message;
+                return RedirectToAction(nameof(Index), "Sport");
+            }
+            
         }
 
         /// <summary>
@@ -112,10 +121,18 @@ namespace TheRealDealGym.Areas.Admin.Controllers
                 return BadRequest();
             }
 
-            await sportService.DeleteAsync(sportId);
+            try
+            {
+                await sportService.DeleteAsync(sportId);
 
-            TempData[MessageError] = "You have successfully deleted this sport!";
-            return RedirectToAction(nameof(Index), "Sport");
+                TempData[MessageError] = "You have successfully deleted this sport!";
+                return RedirectToAction(nameof(Index), "Sport");
+            }
+            catch (Exception ex)
+            {
+                TempData[MessageError] = ex.Message;
+                return RedirectToAction(nameof(Index), "Sport");
+            }
         }
     }
 }

--- a/TheRealDealGym/Areas/Identity/Pages/Account/Login.cshtml
+++ b/TheRealDealGym/Areas/Identity/Pages/Account/Login.cshtml
@@ -26,14 +26,14 @@
                     <label asp-for="Input.Password" class="form-label"></label>
                     <span asp-validation-for="Input.Password" class="text-danger"></span>
                 </div>
-                <div>
+                @* <div>
                     <div class="checkbox">
                         <label asp-for="Input.RememberMe" class="form-label">
                             <input class="form-check-input" asp-for="Input.RememberMe" />
                             @Html.DisplayNameFor(m => m.Input.RememberMe)
                         </label>
                     </div>
-                </div>
+                </div> *@
                 <div>
                     <button id="login-submit" type="submit" class="w-100 btn btn-lg btn-primary" >
                         Log in

--- a/TheRealDealGym/Controllers/ClassController.cs
+++ b/TheRealDealGym/Controllers/ClassController.cs
@@ -176,6 +176,13 @@ namespace TheRealDealGym.Controllers
                 ModelState.AddModelError(nameof(model.SportId), "Sport does not exist!");
             }
 
+            Guid? trainerId = await trainerService.GetTrainerIdAsync(User.GetId());
+
+            if (trainerId.HasValue == false)
+            {
+                return BadRequest();
+            }
+
             if (ModelState.IsValid == false)
             {
                 model.Rooms = await classService.AllRoomAsync();
@@ -186,7 +193,7 @@ namespace TheRealDealGym.Controllers
 
             try
             {
-                await classService.EditAsync(classId, model);
+                await classService.EditAsync(classId, model, trainerId.Value);
 
                 TempData[MessageWarning] = "You have successfully edited this class!";
                 return RedirectToAction(nameof(Details), new { classId });


### PR DESCRIPTION
Delete and Edit Room logic fixed. Now it checks if there are scheduled classes for this room before editing/deleting it.
Delete and Edit Sport logic fixed. Now it checks if there are scheduled classes for this sport before editing/deleting it.
Trainers cannot create or edit a class if it overlaps with any of their already scheduled classes.
Unit tests for these functionalities added.